### PR TITLE
Add files for systemd use, implement gpiod

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # One-liner installation with defaults:
-  `curl https://raw.githubusercontent.com/hipi-io/ups-hat/main/scripts/install-UPS.sh | bash`
+  `curl https://raw.githubusercontent.com/hipi-io/ups-hat/main/systemd/install-UPS-systemd.sh | bash`
 
 ---
 # Manual installation

--- a/scripts/gpiod/ups-gpiod.sh
+++ b/scripts/gpiod/ups-gpiod.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+##################################################################
+# HiPi.io UPS hat service script
+# https://github.com/hipi-io/ups-hat
+##################################################################
+
+### BEGIN INIT INFO
+# Provides: ups
+# Required-Start: $remote_fs
+# Required-Stop: $remote_fs
+# Default-Start: 2 3 4 5
+# Default-Stop: 0 1 6
+# Short-Description: UPS-hat Monitor
+# Description: Starts the HiPi-io UPS HAT Monitor
+### END INIT INFO
+
+#GPIO17 (input) used to read current power status. 
+#0 - normal (or battery power switched on manually). 
+#1 - power fault, switched to battery. 
+#echo 17 > /sys/class/gpio/export;
+#echo in > /sys/class/gpio/gpio17/direction;
+# use gpioget gpiochip0 17
+
+#GPIO27 (input) used to indicate that UPS is online
+#echo 27 > /sys/class/gpio/export;
+#echo in > /sys/class/gpio/gpio27/direction;
+# use gpioget gpiochip0 27
+
+#GPIO18 used to inform UPS that Pi is still working. After power-off this pin returns to Hi-Z state. 
+#echo 18 > /sys/class/gpio/export;
+#echo out > /sys/class/gpio/gpio18/direction;
+#echo 0 > /sys/class/gpio/gpio18/value;
+gpioset gpiochip0 18=0
+
+power_timer=0;
+inval_power="0";
+
+ups_online1="0";
+ups_online2="0";
+ups_online_timer="0";
+
+while true
+do
+	#read GPIO27 pin value
+	#normally, UPS toggles this pin every 0.5s
+	ups_online1=$(gpioget gpiochip0 27);
+	
+	sleep 0.1;
+	
+	ups_online2=$(gpioget gpiochip0 27);
+	
+	ups_online_timer=$((ups_online_timer+1));
+	
+	#toggled?
+	if  (( "$ups_online1" != "$ups_online2" )); then
+		ups_online_timer=0;
+	fi
+	
+	#reset all timers if ups is offline longer than 3s (no toggling detected)
+	if (("$ups_online_timer" > 30)); 
+	then
+		echo "$ups_online_timer";
+		
+		ups_online_timer=30;
+		power_timer=0;
+		inval_power=0;
+		#echo "UPS offline. Exit";
+			#gpioset gpiochip0 18=1  # Tell UPS hat it is no longer monitored (disables the 10-seconds power disconnect)
+		#exit;
+	fi		
+
+	#read GPIO17 pin value
+	inval_power=$(gpioget gpiochip0 17);
+	
+#	echo $inval_power;
+	
+	if (( "$inval_power" == 1 )); then
+		power_timer=$((power_timer+1));
+	else 
+		power_timer=0;
+	fi
+	
+	#If power was not restored in 60 seconds
+	if (( "$power_timer" == 600 )); then 
+		#echo $power_timer;
+		echo "Powering off..."
+		sleep 2;
+		systemctl poweroff; #turn off
+		exit;
+	fi	
+done

--- a/scripts/install-UPS.sh
+++ b/scripts/install-UPS.sh
@@ -8,8 +8,8 @@
 sudo apt update; sudo apt install git -y
 
 # Clone the shell script from the Buyapi.ca repository
-#git clone https://github.com/hipi-io/ups-hat.git
-git clone https://github.com/Martin-HiPi/ups-hat.git
+git clone https://github.com/hipi-io/ups-hat.git
+#git clone https://github.com/Martin-HiPi/ups-hat.git
 
 # Navigate into the UPS script folder
 cd ups-hat/scripts

--- a/scripts/install-UPS.sh
+++ b/scripts/install-UPS.sh
@@ -7,7 +7,7 @@
 # Install git onto your pi
 sudo apt update; sudo apt install git -y
 
-# Clone the shell script from the Buyapi.ca repository
+# Clone the shell script from the HiPi.io repository
 git clone https://github.com/hipi-io/ups-hat.git
 #git clone https://github.com/Martin-HiPi/ups-hat.git
 
@@ -26,6 +26,7 @@ sudo cp -v ups.sh /etc/init.d/ups.sh
 # update the rc file
 sudo update-rc.d ups.sh defaults
 
-echo "Starting the service..."
-sudo systemctl start ups
-echo "Service active!"
+#echo "Starting the service..."
+#sudo systemctl start ups
+#echo "Service active!"
+echo "*** Reboot to activate the service! ***"

--- a/scripts/install-UPS.sh
+++ b/scripts/install-UPS.sh
@@ -16,7 +16,6 @@ cd ups-hat/scripts
 
 # Make the script executable
 sudo chmod -v +x ups.sh
-sudo chmod -v +x ups-hat-service.sh
 
 #copy the script to the init.d directory to run the script on startup
 sudo cp -v ups.sh /etc/init.d/ups.sh

--- a/scripts/install-UPS.sh
+++ b/scripts/install-UPS.sh
@@ -14,10 +14,11 @@ git clone https://github.com/hipi-io/ups-hat
 cd ups-hat/scripts
 
 # Make the script executable
-sudo chmod +x ups.sh
+sudo chmod -v +x ups.sh
+sudo chmod -v +x ups-hat-service.sh
 
 #copy the script to the init.d directory to run the script on startup
 sudo cp -v ups.sh /etc/init.d/ups.sh
 
-#update the rc file
+# update the rc file
 sudo update-rc.d ups.sh defaults

--- a/scripts/install-UPS.sh
+++ b/scripts/install-UPS.sh
@@ -14,10 +14,17 @@ git clone https://github.com/hipi-io/ups-hat
 cd ups-hat/scripts
 
 # Make the script executable
-sudo chmod +x ups.sh
+sudo chmod -v +x ups.sh
 
-#copy the script to the init.d directory to run the script on startup
+# Stop previous instance, if any
+sudo systemctl stop ups
+
+# copy the script to the init.d directory to run the script on startup
 sudo cp -v ups.sh /etc/init.d/ups.sh
 
-#update the rc file
+# update the rc file
 sudo update-rc.d ups.sh defaults
+
+echo "Starting the service..."
+sudo systemctl start ups
+echo "Service active!"

--- a/scripts/install-UPS.sh
+++ b/scripts/install-UPS.sh
@@ -8,7 +8,8 @@
 sudo apt update; sudo apt install git -y
 
 # Clone the shell script from the Buyapi.ca repository
-git clone https://github.com/hipi-io/ups-hat
+#git clone https://github.com/hipi-io/ups-hat.git
+git clone https://github.com/Martin-HiPi/ups-hat.git
 
 # Navigate into the UPS script folder
 cd ups-hat/scripts

--- a/systemd/hipi-io-ups-hat.service
+++ b/systemd/hipi-io-ups-hat.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=HiPi.io UPS hat service
+# inspired from https://github.com/ColonelGerdauf/ups/blob/master/scripts/std_linux.ups.service
+
+[Service]
+Type=exec
+KillMode=process
+ExecStart=/usr/local/sbin/hipi-io-ups-hat-service
+ExecStop=/bin/kill -s QUIT $MAINPID
+ExecReload=/bin/kill -s QUIT $MAINPID
+#ExitType=main
+
+[Install]
+WantedBy=multi-user.target
+#Alias=ups.service

--- a/systemd/install-UPS-systemd.sh
+++ b/systemd/install-UPS-systemd.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+##################################################################
+# HiPi.io UPS hat installation script for systemd
+# https://github.com/hipi-io/ups-hat
+##################################################################
+
+# Install git onto your pi
+#sudo apt update; sudo apt install git gpiod -y
+
+# Clone the shell script from the HiPi-io ups-hat repository
+git clone https://github.com/hipi-io/ups-hat.git  # Production repo
+#git clone https://github.com/Martin-HiPi/ups-hat.git  # Staging repo
+
+# Navigate into the UPS script folder
+cd ups-hat
+
+# Make the service script executable
+sudo chmod -v +x scripts/gpiod/ups-gpiod.sh
+
+# Stop and disable the existing service
+sudo systemctl disable ups hipi-io-ups-hat.service
+sudo systemctl stop ups hipi-io-ups-hat.service
+
+# Remove previous SysV copies of the service
+if [ -e /etc/init.d/ups.sh ]
+then 
+	echo "Removing SystemV service..."
+	sudo killall "ups.sh"
+	sudo rm -v /etc/init.d/ups.sh
+	echo
+	echo "*** REBOOT RECOMMENDED!!! ***"
+	echo
+fi
+
+# copy the hipi-io-ups-hat.service unit file to the /etc/systemd/system directory to run the script on startup
+# Should we use /usr/local/lib/systemd/system, "for use by the system administrator when installing software locally"?
+sudo cp -v systemd/hipi-io-ups-hat.service /etc/systemd/system/hipi-io-ups-hat.service
+sudo chown -v root:root /etc/systemd/system/hipi-io-ups-hat.service
+
+# copy the UPS hat script to /usr/local/sbin (Tertiary hierarchy for local data, specific to this host.)
+sudo cp -v scripts/gpiod/ups-gpiod.sh /usr/local/sbin/hipi-io-ups-hat-service
+sudo chown -v root:root /usr/local/sbin/hipi-io-ups-hat-service
+
+# reload daemons
+sudo systemctl daemon-reload
+
+echo "Starting UPS hat service..."
+sudo systemctl enable hipi-io-ups-hat.service
+sudo systemctl start hipi-io-ups-hat.service
+
+echo "Service hipi-io-ups-hat.service should be active!"
+#ps -aux | grep "hipi-io-ups-hat-service"
+sudo systemctl status hipi-io-ups-hat.service


### PR DESCRIPTION
Add the files needed to use systemd instead of SysV,
Implement use of gpiod in the files used by the systemd installation,
Make the one-liner use systemd+gpiod when installing.