### PR TITLE
LibreELEC 10 Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ---
 # Manual installation
 
-## change the permissions for the script 
+## change the permissions for the script
 
   `sudo chmod +x ups.sh`
 

--- a/scripts/gpiod/ups-gpiod.sh
+++ b/scripts/gpiod/ups-gpiod.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 ##################################################################
 # HiPi.io UPS hat service script
 # https://github.com/hipi-io/ups-hat
@@ -52,12 +52,12 @@ do
 	ups_online_timer=$((ups_online_timer+1));
 
 	#toggled?
-	if  (( "$ups_online1" != "$ups_online2" )); then
+	if [ "$ups_online1" -ne "$ups_online2" ]; then
 		ups_online_timer=0;
 	fi
 
 	#reset all timers if ups is offline longer than 3s (no toggling detected)
-	if (("$ups_online_timer" > 30));
+	if [ "$ups_online_timer" -gt 30 ];
 	then
 		echo "$ups_online_timer";
 
@@ -74,14 +74,14 @@ do
 
 #	echo $inval_power;
 
-	if (( "$inval_power" == 1 )); then
+	if [ "$inval_power" -eq 1 ]; then
 		power_timer=$((power_timer+1));
 	else
 		power_timer=0;
 	fi
 
 	#If power was not restored in 60 seconds
-	if (( "$power_timer" == 600 )); then
+	if [ "$power_timer" -eq 600 ]; then
 		#echo $power_timer;
 		echo "Powering off..."
 		sleep 2;

--- a/scripts/gpiod/ups-gpiod.sh
+++ b/scripts/gpiod/ups-gpiod.sh
@@ -17,75 +17,75 @@
 #GPIO17 (input) used to read current power status.
 #0 - normal (or battery power switched on manually).
 #1 - power fault, switched to battery.
-#echo 17 > /sys/class/gpio/export;
-#echo in > /sys/class/gpio/gpio17/direction;
+#echo 17 > /sys/class/gpio/export
+#echo in > /sys/class/gpio/gpio17/direction
 # use gpioget gpiochip0 17
 
 #GPIO27 (input) used to indicate that UPS is online
-#echo 27 > /sys/class/gpio/export;
-#echo in > /sys/class/gpio/gpio27/direction;
+#echo 27 > /sys/class/gpio/export
+#echo in > /sys/class/gpio/gpio27/direction
 # use gpioget gpiochip0 27
 
 #GPIO18 used to inform UPS that Pi is still working. After power-off this pin returns to Hi-Z state.
-#echo 18 > /sys/class/gpio/export;
-#echo out > /sys/class/gpio/gpio18/direction;
-#echo 0 > /sys/class/gpio/gpio18/value;
+#echo 18 > /sys/class/gpio/export
+#echo out > /sys/class/gpio/gpio18/direction
+#echo 0 > /sys/class/gpio/gpio18/value
 gpioset gpiochip0 18=0
 
-power_timer=0;
-inval_power="0";
+power_timer=0
+inval_power="0"
 
-ups_online1="0";
-ups_online2="0";
-ups_online_timer="0";
+ups_online1="0"
+ups_online2="0"
+ups_online_timer="0"
 
 while true
 do
 	#read GPIO27 pin value
 	#normally, UPS toggles this pin every 0.5s
-	ups_online1=$(gpioget gpiochip0 27);
+	ups_online1=$(gpioget gpiochip0 27)
 
-	sleep 0.1;
+	sleep 0.1
 
-	ups_online2=$(gpioget gpiochip0 27);
+	ups_online2=$(gpioget gpiochip0 27)
 
-	ups_online_timer=$((ups_online_timer+1));
+	ups_online_timer=$((ups_online_timer+1))
 
 	#toggled?
 	if [ "$ups_online1" -ne "$ups_online2" ]; then
-		ups_online_timer=0;
+		ups_online_timer=0
 	fi
 
 	#reset all timers if ups is offline longer than 3s (no toggling detected)
-	if [ "$ups_online_timer" -gt 30 ];
+	if [ "$ups_online_timer" -gt 30 ]
 	then
-		echo "$ups_online_timer";
+		echo "$ups_online_timer"
 
-		ups_online_timer=30;
-		power_timer=0;
-		inval_power=0;
-		#echo "UPS offline. Exit";
+		ups_online_timer=30
+		power_timer=0
+		inval_power=0
+		#echo "UPS offline. Exit"
 			#gpioset gpiochip0 18=1  # Tell UPS hat it is no longer monitored (disables the 10-seconds power disconnect)
-		#exit;
+		#exit
 	fi
 
 	#read GPIO17 pin value
-	inval_power=$(gpioget gpiochip0 17);
+	inval_power=$(gpioget gpiochip0 17)
 
-#	echo $inval_power;
+#	echo $inval_power
 
 	if [ "$inval_power" -eq 1 ]; then
-		power_timer=$((power_timer+1));
+		power_timer=$((power_timer+1))
 	else
-		power_timer=0;
+		power_timer=0
 	fi
 
 	#If power was not restored in 60 seconds
 	if [ "$power_timer" -eq 600 ]; then
-		#echo $power_timer;
+		#echo $power_timer
 		echo "Powering off..."
-		sleep 2;
+		sleep 2
 		systemctl poweroff; #turn off
-		exit;
+		exit
 	fi
 done

--- a/scripts/gpiod/ups-gpiod.sh
+++ b/scripts/gpiod/ups-gpiod.sh
@@ -14,9 +14,9 @@
 # Description: Starts the HiPi-io UPS HAT Monitor
 ### END INIT INFO
 
-#GPIO17 (input) used to read current power status. 
-#0 - normal (or battery power switched on manually). 
-#1 - power fault, switched to battery. 
+#GPIO17 (input) used to read current power status.
+#0 - normal (or battery power switched on manually).
+#1 - power fault, switched to battery.
 #echo 17 > /sys/class/gpio/export;
 #echo in > /sys/class/gpio/gpio17/direction;
 # use gpioget gpiochip0 17
@@ -26,7 +26,7 @@
 #echo in > /sys/class/gpio/gpio27/direction;
 # use gpioget gpiochip0 27
 
-#GPIO18 used to inform UPS that Pi is still working. After power-off this pin returns to Hi-Z state. 
+#GPIO18 used to inform UPS that Pi is still working. After power-off this pin returns to Hi-Z state.
 #echo 18 > /sys/class/gpio/export;
 #echo out > /sys/class/gpio/gpio18/direction;
 #echo 0 > /sys/class/gpio/gpio18/value;
@@ -44,48 +44,48 @@ do
 	#read GPIO27 pin value
 	#normally, UPS toggles this pin every 0.5s
 	ups_online1=$(gpioget gpiochip0 27);
-	
+
 	sleep 0.1;
-	
+
 	ups_online2=$(gpioget gpiochip0 27);
-	
+
 	ups_online_timer=$((ups_online_timer+1));
-	
+
 	#toggled?
 	if  (( "$ups_online1" != "$ups_online2" )); then
 		ups_online_timer=0;
 	fi
-	
+
 	#reset all timers if ups is offline longer than 3s (no toggling detected)
-	if (("$ups_online_timer" > 30)); 
+	if (("$ups_online_timer" > 30));
 	then
 		echo "$ups_online_timer";
-		
+
 		ups_online_timer=30;
 		power_timer=0;
 		inval_power=0;
 		#echo "UPS offline. Exit";
 			#gpioset gpiochip0 18=1  # Tell UPS hat it is no longer monitored (disables the 10-seconds power disconnect)
 		#exit;
-	fi		
+	fi
 
 	#read GPIO17 pin value
 	inval_power=$(gpioget gpiochip0 17);
-	
+
 #	echo $inval_power;
-	
+
 	if (( "$inval_power" == 1 )); then
 		power_timer=$((power_timer+1));
-	else 
+	else
 		power_timer=0;
 	fi
-	
+
 	#If power was not restored in 60 seconds
-	if (( "$power_timer" == 600 )); then 
+	if (( "$power_timer" == 600 )); then
 		#echo $power_timer;
 		echo "Powering off..."
 		sleep 2;
 		systemctl poweroff; #turn off
 		exit;
-	fi	
+	fi
 done

--- a/scripts/ups-reset.py
+++ b/scripts/ups-reset.py
@@ -5,7 +5,7 @@ try:
     import RPi.GPIO as GPIO
 except RuntimeError:
     print("Error importing RPi.GPIO!  This is probably because you need superuser privileges.  You can achieve this by using 'sudo' to run your script")
-  
+
 GPIO.setmode(GPIO.BCM)
 GPIO.setwarnings(False)
 

--- a/scripts/ups-set.py
+++ b/scripts/ups-set.py
@@ -5,7 +5,7 @@ try:
     import RPi.GPIO as GPIO
 except RuntimeError:
     print("Error importing RPi.GPIO!  This is probably because you need superuser privileges.  You can achieve this by using 'sudo' to run your script")
-  
+
 GPIO.setmode(GPIO.BCM)
 GPIO.setwarnings(False)
 

--- a/scripts/ups.sh
+++ b/scripts/ups.sh
@@ -33,18 +33,18 @@ gpio_set_sysfs() {
 	### Configure the needed GPIO
 	# NOTE: SysFS has no method to handle Pull-up/downs!!!
 	#
-	# GPIO17 (input) used to read current power status. 
-	# 0 - normal (or battery power switched on manually). 
-	# 1 - power fault, switched to battery. 
+	# GPIO17 (input) used to read current power status.
+	# 0 - normal (or battery power switched on manually).
+	# 1 - power fault, switched to battery.
 	echo 17 > /sys/class/gpio/export;
 	echo in > /sys/class/gpio/gpio17/direction;
-	
+
 	# GPIO27 (input) used to indicate that UPS is online
 	# 1Hz = normal
 	echo 27 > /sys/class/gpio/export;
 	echo in > /sys/class/gpio/gpio27/direction;
-	
-	# GPIO18 used to inform UPS that Pi is still working. 
+
+	# GPIO18 used to inform UPS that Pi is still working.
 	# After power-off, this pin returns to Hi-Z state (read as high by hat).
 	# Returning to hi-Z/high starts a 10-seconds timer to power disconnect.
 	echo 18 > /sys/class/gpio/export;
@@ -57,7 +57,7 @@ gpio_set_py() {
 	# 1Hz = normal
 	#echo 27 > /sys/class/gpio/export;
 	#echo in > /sys/class/gpio/gpio27/direction;
-	
+
 	# Using a RPi.GPIO Python script allows pull-up/down control
 	# Installed by default with Raspberry Pi OS
 	/usr/local/sbin/hipi-io-ups-hat-gpio-set;
@@ -66,63 +66,63 @@ gpio_set_py() {
 main_loop() {
 	power_timer=0;
 	inval_power="0";
-	
+
 	ups_online1="0";
 	ups_online2="0";
 	ups_online_timer="0";
-	
+
 	while true
 	do
 		# read GPIO27 pin value
 		# normally, UPS toggles this pin every 0.5s
 		ups_online1=$(cat /sys/class/gpio/gpio27/value);
-		
+
 		sleep 0.1;
-		
+
 		ups_online2=$(cat /sys/class/gpio/gpio27/value);
-		
+
 		ups_online_timer=$((ups_online_timer+1));
-		
+
 		# toggled?
 		if  (( "$ups_online1" != "$ups_online2" )); then
 			ups_online_timer=0;
 		fi
-		
+
 		# reset all timers if ups is offline longer than 3s (no toggling detected)
-		if (("$ups_online_timer" > 30)); 
+		if (("$ups_online_timer" > 30));
 		then
 			echo "$ups_online_timer";
-			
+
 			ups_online_timer=30;
 			power_timer=0;
 			inval_power=0;
 			#echo "UPS offline. Exit";
 			#exit;
-		fi		
-	
+		fi
+
 		# read GPIO17 pin value
 		inval_power=$(cat /sys/class/gpio/gpio17/value);
-		
+
 		#echo "inval_power= "$inval_power;
-		
+
 		if (( "$inval_power" == 1 )); then
 			power_timer=$((power_timer+1));
-		else 
+		else
 			power_timer=0;
 		fi
-			
+
 		#echo "power_timer=     "$power_timer;
-		
+
 		# If power was not restored in 60 seconds
-		if (( "$power_timer" == 600 )); then 
+		if (( "$power_timer" == 600 )); then
 			echo "Powering off..."
 			sleep 2;
 			systemctl poweroff; #turn off
 			exit;
 		fi
-		
+
 		if [ -e /tmp/ups-hat.exit ]
-		then 
+		then
 			#break
 			echo "Shutting down service..."
 			gpio_reset_py;
@@ -132,13 +132,13 @@ main_loop() {
 			touch /tmp/ups-hat.quit;
 			#gpio_reset_py;
 			rm -v /tmp/ups-hat.exit;
-			
+
 			exit;
 
 		fi
-	
+
 	done
-	
+
 }
 
 main() {

--- a/scripts/ups.sh
+++ b/scripts/ups.sh
@@ -26,7 +26,7 @@ gpio_reset_sysfs() {
 gpio_reset_py() {
 	# Using a RPi.GPIO Python script allows pull-up/down control
 	# Installed by default with Raspberry Pi OS
-	/usr/local/sbin/hipi-io-ups-hat-gpio-reset;
+	/usr/local/sbin/hipi-io-ups-hat-gpio-reset
 }
 
 gpio_set_sysfs() {
@@ -36,104 +36,104 @@ gpio_set_sysfs() {
 	# GPIO17 (input) used to read current power status.
 	# 0 - normal (or battery power switched on manually).
 	# 1 - power fault, switched to battery.
-	echo 17 > /sys/class/gpio/export;
-	echo in > /sys/class/gpio/gpio17/direction;
+	echo 17 > /sys/class/gpio/export
+	echo in > /sys/class/gpio/gpio17/direction
 
 	# GPIO27 (input) used to indicate that UPS is online
 	# 1Hz = normal
-	echo 27 > /sys/class/gpio/export;
-	echo in > /sys/class/gpio/gpio27/direction;
+	echo 27 > /sys/class/gpio/export
+	echo in > /sys/class/gpio/gpio27/direction
 
 	# GPIO18 used to inform UPS that Pi is still working.
 	# After power-off, this pin returns to Hi-Z state (read as high by hat).
 	# Returning to hi-Z/high starts a 10-seconds timer to power disconnect.
-	echo 18 > /sys/class/gpio/export;
-	echo out > /sys/class/gpio/gpio18/direction;
-	echo 0 > /sys/class/gpio/gpio18/value;
+	echo 18 > /sys/class/gpio/export
+	echo out > /sys/class/gpio/gpio18/direction
+	echo 0 > /sys/class/gpio/gpio18/value
 }
 
 gpio_set_py() {
 	# GPIO27 (input) used to indicate that UPS is online
 	# 1Hz = normal
-	#echo 27 > /sys/class/gpio/export;
-	#echo in > /sys/class/gpio/gpio27/direction;
+	#echo 27 > /sys/class/gpio/export
+	#echo in > /sys/class/gpio/gpio27/direction
 
 	# Using a RPi.GPIO Python script allows pull-up/down control
 	# Installed by default with Raspberry Pi OS
-	/usr/local/sbin/hipi-io-ups-hat-gpio-set;
+	/usr/local/sbin/hipi-io-ups-hat-gpio-set
 }
 
 main_loop() {
-	power_timer=0;
-	inval_power="0";
+	power_timer=0
+	inval_power="0"
 
-	ups_online1="0";
-	ups_online2="0";
-	ups_online_timer="0";
+	ups_online1="0"
+	ups_online2="0"
+	ups_online_timer="0"
 
 	while true
 	do
 		# read GPIO27 pin value
 		# normally, UPS toggles this pin every 0.5s
-		ups_online1=$(cat /sys/class/gpio/gpio27/value);
+		ups_online1=$(cat /sys/class/gpio/gpio27/value)
 
-		sleep 0.1;
+		sleep 0.1
 
-		ups_online2=$(cat /sys/class/gpio/gpio27/value);
+		ups_online2=$(cat /sys/class/gpio/gpio27/value)
 
-		ups_online_timer=$((ups_online_timer+1));
+		ups_online_timer=$((ups_online_timer+1))
 
 		# toggled?
 		if [ "$ups_online1" -ne "$ups_online2" ]; then
-			ups_online_timer=0;
+			ups_online_timer=0
 		fi
 
 		# reset all timers if ups is offline longer than 3s (no toggling detected)
-		if [ "$ups_online_timer" -gt 30 ];
+		if [ "$ups_online_timer" -gt 30 ]
 		then
-			echo "$ups_online_timer";
+			echo "$ups_online_timer"
 
-			ups_online_timer=30;
-			power_timer=0;
-			inval_power=0;
-			#echo "UPS offline. Exit";
-			#exit;
+			ups_online_timer=30
+			power_timer=0
+			inval_power=0
+			#echo "UPS offline. Exit"
+			#exit
 		fi
 
 		# read GPIO17 pin value
-		inval_power=$(cat /sys/class/gpio/gpio17/value);
+		inval_power=$(cat /sys/class/gpio/gpio17/value)
 
-		#echo "inval_power= "$inval_power;
+		#echo "inval_power= "$inval_power
 
 		if [ "$inval_power" -eq 1 ]; then
-			power_timer=$((power_timer+1));
+			power_timer=$((power_timer+1))
 		else
-			power_timer=0;
+			power_timer=0
 		fi
 
-		#echo "power_timer=     "$power_timer;
+		#echo "power_timer=     "$power_timer
 
 		# If power was not restored in 60 seconds
 		if [ "$power_timer" -eq 600 ]; then
 			echo "Powering off..."
-			sleep 2;
+			sleep 2
 			systemctl poweroff; #turn off
-			exit;
+			exit
 		fi
 
 		if [ -e /tmp/ups-hat.exit ]
 		then
 			#break
 			echo "Shutting down service..."
-			gpio_reset_py;
+			gpio_reset_py
 			echo
 			echo "*** UPS service stopped ***"
 			echo
-			touch /tmp/ups-hat.quit;
-			#gpio_reset_py;
-			rm -v /tmp/ups-hat.exit;
+			touch /tmp/ups-hat.quit
+			#gpio_reset_py
+			rm -v /tmp/ups-hat.exit
 
-			exit;
+			exit
 
 		fi
 
@@ -142,13 +142,13 @@ main_loop() {
 }
 
 main() {
-	gpio_reset_py;
-	gpio_reset_sysfs;
+	gpio_reset_py
+	gpio_reset_sysfs
 	if [ -e /tmp/ups-hat.exit ]; then rm -v /tmp/ups-hat.exit; fi
 	if [ -e /tmp/ups-hat.quit ]; then rm -v /tmp/ups-hat.quit; fi
-	gpio_set_sysfs;
-	gpio_set_py;
-	main_loop;
+	gpio_set_sysfs
+	gpio_set_py
+	main_loop
 }
 
 main

--- a/scripts/ups.sh
+++ b/scripts/ups.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 ##################################################################
 # HiPi.io UPS hat service script
 # https://github.com/hipi-io/ups-hat
@@ -84,12 +84,12 @@ main_loop() {
 		ups_online_timer=$((ups_online_timer+1));
 
 		# toggled?
-		if  (( "$ups_online1" != "$ups_online2" )); then
+		if [ "$ups_online1" -ne "$ups_online2" ]; then
 			ups_online_timer=0;
 		fi
 
 		# reset all timers if ups is offline longer than 3s (no toggling detected)
-		if (("$ups_online_timer" > 30));
+		if [ "$ups_online_timer" -gt 30 ];
 		then
 			echo "$ups_online_timer";
 
@@ -105,7 +105,7 @@ main_loop() {
 
 		#echo "inval_power= "$inval_power;
 
-		if (( "$inval_power" == 1 )); then
+		if [ "$inval_power" -eq 1 ]; then
 			power_timer=$((power_timer+1));
 		else
 			power_timer=0;
@@ -114,7 +114,7 @@ main_loop() {
 		#echo "power_timer=     "$power_timer;
 
 		# If power was not restored in 60 seconds
-		if (( "$power_timer" == 600 )); then
+		if [ "$power_timer" -eq 600 ]; then
 			echo "Powering off..."
 			sleep 2;
 			systemctl poweroff; #turn off

--- a/systemd/hipi-io-ups-hat.service
+++ b/systemd/hipi-io-ups-hat.service
@@ -7,7 +7,7 @@ Type=exec
 KillMode=none
 ExecStart=/usr/local/sbin/hipi-io-ups-hat-service
 ExecStop=/usr/bin/touch /tmp/ups-hat.exit
-#ExecStop=/bin/kill -s QUIT $MAINPID; 
+#ExecStop=/bin/kill -s QUIT $MAINPID;
 #ExecReload=/bin/kill -s QUIT $MAINPID
 #ExitType=main
 

--- a/systemd/install-UPS-systemd.sh
+++ b/systemd/install-UPS-systemd.sh
@@ -29,12 +29,12 @@ sudo systemctl stop hipi-io-ups-hat.service
 
 # Remove previous SysV copies of the service
 if [ -e /etc/init.d/ups.sh ]
-then 
+then
 	echo "Shutting down the UPS hat service..."
 	touch /tmp/ups-hat.exit
-	
+
 	sleep 5
-	
+
 	if [ -e /tmp/ups-hat.quit ]
 	then
 		echo "... Service for UPS hat stopped!"
@@ -44,7 +44,7 @@ then
 		sudo killall "ups.sh"
 		sudo rm -v /tmp/ups-hat.*
 	fi
-	
+
 	echo "Removing SystemV service..."
 	sudo update-rc.d ups.sh disable
 	sudo rm -v /etc/init.d/ups.sh


### PR DESCRIPTION
Convert bash scripts to be POSIX compatible.
LibreELEC is based on busybox, so bash is actually an alias for ash on that platform.
ash doesn't support bare double-parenthesis for arithmetic evaluations, so they've been replaced with '[' (aka 'test') evaluations.

LibreELEC also use some different paths for SD card storage and additional python libraries. The sed commands below perform the appropriate edits, but these changes could be implemented directly with some conditional statements.

LibreELEC 10.0 instructions:
```
#Preference (gear icon) -> LibreELEC -> Services -> Enable SSH
#Preference (gear icon) -> Add-ons -> Install from repository -> LibreELEC Add-ons -> Program Add-ons -> Install System Tools and Raspberry Pi Tools

ssh root@X.X.X.X

mount -o remount,rw /flash
echo 'dtparam=i2c_arm=on' >> /flash/config.txt
mount -o remount,ro /flash

cd /tmp
curl -o ups-hat-main.tar.gz -L https://github.com/skinlayers/ups-hat/archive/refs/heads/main.tar.gz
tar xf ups-hat-main.tar.gz
cd ups-hat-main

cp systemd/hipi-io-ups-hat.service /storage/.config/system.d/
sed -i 's|ExecStart=/usr/local|ExecStart=/storage/.ups|' /storage/.config/system.d/hipi-io-ups-hat.service

mkdir -p /storage/.ups/sbin
cp -v scripts/ups.sh /storage/.ups/sbin/hipi-io-ups-hat-service
cp -v scripts/ups-set.py /storage/.ups/sbin/hipi-io-ups-hat-gpio-set
cp -v scripts/ups-reset.py /storage/.ups/sbin/hipi-io-ups-hat-gpio-reset

sed -i 's|/usr/local|/storage/.ups|g' /storage/.ups/sbin/hipi-io-ups-hat-service

sed -i "/^import sys$/a sys.path.append('\/storage\/.kodi\/addons\/virtual.rpi-tools\/lib')" /storage/.ups/sbin/hipi-io-ups-hat-gpio-set
sed -i "/^import sys$/a sys.path.append('\/storage\/.kodi\/addons\/virtual.rpi-tools\/lib')" /storage/.ups/sbin/hipi-io-ups-hat-gpio-reset

chmod +x /storage/.ups/sbin/hipi-io-ups-hat-service
chmod +x /storage/.ups/sbin/hipi-io-ups-hat-gpio-set
chmod +x /storage/.ups/sbin/hipi-io-ups-hat-gpio-reset

systemctl daemon-reload

systemctl enable hipi-io-ups-hat.service --no-pager
systemctl start hipi-io-ups-hat.service --no-pager

echo "Service hipi-io-ups-hat.service should be active!"
systemctl status hipi-io-ups-hat.service --no-pager
```