### PR TITLE
Fix multiple issues with gpioset and gpioget

### DIFF
--- a/scripts/Bullseye/ups-gpiod.sh
+++ b/scripts/Bullseye/ups-gpiod.sh
@@ -32,7 +32,7 @@
 #echo out > /sys/class/gpio/gpio18/direction
 #echo 0 > /sys/class/gpio/gpio18/value
 # use gpioset gpiochip0 GPIO18
-gpioset 0 18=0
+gpioset -c 0 18=0
 
 power_timer=0
 inval_power="0"
@@ -53,11 +53,11 @@ while true
 do
 	# Read GPIO27 pin value
 	# Normally, UPS toggles this pin every 0.5s
-	ups_online1=$(gpioget 0 27)
+	ups_online1=$(gpioget -c 0 27)
 
 	sleep 0.1
 
-	ups_online2=$(gpioget 0 27)
+	ups_online2=$(gpioget -c 0 27)
 
 	ups_online_timer=$((ups_online_timer+1))
 
@@ -76,12 +76,12 @@ do
 		power_timer=0
 		inval_power=0
 		echo "### UPS offline. Exit"
-			gpioset 0 18=1  # Tell UPS hat it is no longer monitored (disables the 10-seconds power disconnect)
+			gpioset -c 0 18=1  # Tell UPS hat it is no longer monitored (disables the 10-seconds power disconnect)
 		exit
 	fi
 
 	# Read GPIO17 pin value (What is the power status?)
-	inval_power=$(gpioget 0 17)
+	inval_power=$(gpioget -c 0 17)
 
 	if [ "$inval_power" -eq 1 ]; then
 		power_timer=$((power_timer+1))

--- a/scripts/Bullseye/ups-gpiod.sh
+++ b/scripts/Bullseye/ups-gpiod.sh
@@ -15,6 +15,8 @@
 # Description: Starts the HiPi-io UPS HAT Monitor
 ### END INIT INFO
 
+echo "starting..."
+
 # GPIO17 (input) used to read current power status.
 # 0 - normal (or battery power switched on manually).
 # 1 - power fault, switched to battery.
@@ -43,7 +45,7 @@ ups_online_timer="0"
 
 trap_ctrlc() {
     echo "Exiting..."
-	gpioset 0 18=1
+	gpioset -c 0 18=1
 	exit
 }
 

--- a/scripts/Bullseye/ups-gpiod.sh
+++ b/scripts/Bullseye/ups-gpiod.sh
@@ -15,7 +15,7 @@
 # Description: Starts the HiPi-io UPS HAT Monitor
 ### END INIT INFO
 
-echo "starting..."
+echo "Begin..."
 
 # GPIO17 (input) used to read current power status.
 # 0 - normal (or battery power switched on manually).
@@ -34,32 +34,38 @@ echo "starting..."
 #echo out > /sys/class/gpio/gpio18/direction
 #echo 0 > /sys/class/gpio/gpio18/value
 # use gpioset gpiochip0 GPIO18
-gpioset -c 0 18=0
+echo "Init..."
+
 
 power_timer=0
-inval_power="0"
+inval_power=0
 
-ups_online1="0"
-ups_online2="0"
-ups_online_timer="0"
+ups_online1=0
+ups_online2=0
+ups_online_timer=0
 
+echo "Setting exit trap..."
 trap_ctrlc() {
     echo "Exiting..."
-	gpioset -c 0 18=1
+	gpioset --daemonize -c 0 18=1
 	exit
 }
 
 trap trap_ctrlc INT
 
+echo "Starting..."
+gpioset --daemonize -c 0 18=0
+
 while true
 do
+	#echo "loop"
 	# Read GPIO27 pin value
 	# Normally, UPS toggles this pin every 0.5s
-	ups_online1=$(gpioget -c 0 27)
+	ups_online1=$(gpioget --numeric -c 0 27)
 
 	sleep 0.1
 
-	ups_online2=$(gpioget -c 0 27)
+	ups_online2=$(gpioget --numeric -c 0 27)
 
 	ups_online_timer=$((ups_online_timer+1))
 
@@ -83,7 +89,7 @@ do
 	fi
 
 	# Read GPIO17 pin value (What is the power status?)
-	inval_power=$(gpioget -c 0 17)
+	inval_power=$(gpioget --numeric -c 0 17)
 
 	if [ "$inval_power" -eq 1 ]; then
 		power_timer=$((power_timer+1))

--- a/systemd/hipi-io-ups-hat.service
+++ b/systemd/hipi-io-ups-hat.service
@@ -4,7 +4,7 @@ Description=HiPi.io UPS hat service
 
 [Service]
 Type=exec
-KillMode=none
+KillMode=mixed
 ExecStart=/usr/local/sbin/hipi-io-ups-hat-service
 ExecStop=/usr/bin/touch /tmp/ups-hat.exit
 #ExecStop=/bin/kill -s QUIT $MAINPID;


### PR DESCRIPTION
Fix multiple issues related to the gpioset and gpioget commands causing the script to fail monitoring power and gracefully shut down the Pi. Issues discovered while testing on Trixie but likely applied to previous OSes as well.

Change KillMode from none to mixed, closing #12 